### PR TITLE
Add validation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,8 @@
       "ignoreComments": true,
       "ignoreUrls": true,
       "ignoreStrings": true,
-      "ignoreRegExpLiterals": true
+      "ignoreRegExpLiterals": true,
+      "code": 120
     }]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,10 @@
     "node": true,
     "es6": true
   },
+  "parserOptions": {
+    "ecmaVersion": 2017,
+    "sourceType": "module"
+  },
   "rules": {
     "max-len": ["error", {
       "ignoreComments": true,

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,0 +1,13 @@
+FROM node:7.9.0-alpine
+MAINTAINER Superbalist <tech+docker@superbalist.com>
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY package.json /usr/src/app/
+RUN yarn install
+
+COPY src /usr/src/app/src/
+
+EXPOSE 3000
+CMD ["node", "./src/bin/www"]

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ When you start the `js-pubsub-rest-proxy` image, you can adjust the configuratio
 | GOOGLE_CLOUD_PROJECT_ID        | null      |                                                                    |
 | GOOGLE_APPLICATION_CREDENTIALS | null      | The full path to the file containing the Google Cloud credentials  |
 | GOOGLE_CLOUD_CLIENT_IDENTIFIER | null      | The client identifier used when talking to Google Cloud            |
+| VALIDATION_ERROR_SCHEMA_URL    | false     | The url for invalid event schema below. Enables validation
+|
+| VALIDATION_ERROR_CHANNEL       | validation_error | The channel to publish validation errors to
+|
 
 ## Running
 
@@ -85,4 +89,23 @@ $ docker run \
   -e GOOGLE_CLOUD_PROJECT_ID='your-project-id-here' \
   -e GOOGLE_APPLICATION_CREDENTIALS='/etc/gcloud_credentials.json' \
   superbalist/js-pubsub-rest-proxy
+```
+
+## Validation Error Schema
+```
+"properties": {
+  "schema": {
+      "type": "string",
+      "format": "uri"
+  },
+  "meta": {
+      "type": "object"
+  },
+  "event": {
+      "type": "object"
+  },
+  "errors": {
+      "type": "array"
+  }
+}
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ When you start the `js-pubsub-rest-proxy` image, you can adjust the configuratio
 | GOOGLE_CLOUD_CLIENT_IDENTIFIER | null      | The client identifier used when talking to Google Cloud            |
 | VALIDATION_ERROR_SCHEMA_URL    | false     | The url for invalid event schema below. Enables validation         |
 | VALIDATION_ERROR_CHANNEL       | validation_error | The channel to publish validation errors to                 |
-| PUBLISH_INVALID                | true      | Publish invalid events (true, false)                      |
+| PUBLISH_INVALID                | true      | Publish invalid events (true, false)                               |
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ When you start the `js-pubsub-rest-proxy` image, you can adjust the configuratio
 | GOOGLE_CLOUD_CLIENT_IDENTIFIER | null      | The client identifier used when talking to Google Cloud            |
 | VALIDATION_ERROR_SCHEMA_URL    | false     | The url for invalid event schema below. Enables validation         |
 | VALIDATION_ERROR_CHANNEL       | validation_error | The channel to publish validation errors to                 |
-| PUBLISH_INVALID                | true      | Publish invalid events (true(default), false)                      |
+| PUBLISH_INVALID                | true      | Publish invalid events (true, false)                      |
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ When you start the `js-pubsub-rest-proxy` image, you can adjust the configuratio
 | GOOGLE_CLOUD_CLIENT_IDENTIFIER | null      | The client identifier used when talking to Google Cloud            |
 | VALIDATION_ERROR_SCHEMA_URL    | false     | The url for invalid event schema below. Enables validation         |
 | VALIDATION_ERROR_CHANNEL       | validation_error | The channel to publish validation errors to                 |
+| PUBLISH_INVALID                | true      | Publish invalid events where they were intended to go anyway       |
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ When you start the `js-pubsub-rest-proxy` image, you can adjust the configuratio
 | GOOGLE_CLOUD_CLIENT_IDENTIFIER | null      | The client identifier used when talking to Google Cloud            |
 | VALIDATION_ERROR_SCHEMA_URL    | false     | The url for invalid event schema below. Enables validation         |
 | VALIDATION_ERROR_CHANNEL       | validation_error | The channel to publish validation errors to                 |
-| PUBLISH_INVALID                | true      | Publish invalid events where they were intended to go anyway       |
+| PUBLISH_INVALID                | true      | Publish invalid events (true(default), false)                      |
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,8 @@ When you start the `js-pubsub-rest-proxy` image, you can adjust the configuratio
 | GOOGLE_CLOUD_PROJECT_ID        | null      |                                                                    |
 | GOOGLE_APPLICATION_CREDENTIALS | null      | The full path to the file containing the Google Cloud credentials  |
 | GOOGLE_CLOUD_CLIENT_IDENTIFIER | null      | The client identifier used when talking to Google Cloud            |
-| VALIDATION_ERROR_SCHEMA_URL    | false     | The url for invalid event schema below. Enables validation
-|
-| VALIDATION_ERROR_CHANNEL       | validation_error | The channel to publish validation errors to
-|
+| VALIDATION_ERROR_SCHEMA_URL    | false     | The url for invalid event schema below. Enables validation         |
+| VALIDATION_ERROR_CHANNEL       | validation_error | The channel to publish validation errors to                 |
 
 ## Running
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0 2018-12-13
+
+* Added schema validation checking
+
 ## 1.0.3 2018-12-06
 
 * Added more prometheus metrics

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   },
   "homepage": "https://github.com/Superbalist/js-pubsub-rest-proxy#readme",
   "dependencies": {
+    "@superbalist/js-event-pubsub": "^3.0.2",
     "@superbalist/js-pubsub-manager": "^3.0.1",
+    "ajv": "^5.0.1",
     "body-parser": "^1.17.2",
     "debug": "~2.6.3",
     "express": "^4.15.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superbalist/js-pubsub-rest-proxy",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "An HTTP server which acts as a gateway for publishing messages via a js-pubsub adapter",
   "private": true,
   "scripts": {

--- a/src/app.js
+++ b/src/app.js
@@ -99,7 +99,6 @@ let onExitHandler = () => {
   logger.info('Stopping queue timer');
   clearInterval(queue.timer);
 
-  logger.info('Processing remaining jobs on queue');
   logger.info('Closing express server socket');
   // When the HTTP server closes we want to empty the job queue.
   app.server.close(emptyQueue);
@@ -113,6 +112,7 @@ function emptyQueue() {
   if(queue.length == 0) {
     process.exit(0);
   } else {
+    logger.info('Processing remaining jobs on queue');
     queue.start(emptyQueue);
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -16,9 +16,6 @@ let logger = require('./logger');
 let pubsub = require('./pubsub');
 let queue = require('./queue');
 
-// this flag indicates whether or not we'll accept messages on the POST end-point
-// when a SIGTERM is received, we set this flag to false and throw back a 503
-
 // bootstrap app
 let app = express();
 app.use(morgan('dev'));

--- a/src/app.js
+++ b/src/app.js
@@ -105,6 +105,10 @@ let onExitHandler = () => {
   app.server.close(emptyQueue);
 };
 
+
+/**
+ * Run the queue and exit if it is empty
+ */
 function emptyQueue() {
   if(queue.length == 0) {
     process.exit(0);

--- a/src/config.js
+++ b/src/config.js
@@ -6,6 +6,7 @@ const config = {
   MAX_POST_SIZE: process.env.MAX_POST_SIZE || '10mb',
   PROMETHEUS_EXPORTER: process.env.PROMETHEUS_EXPORTER_ENABLED || false,
   PROMETHEUS_PORT: process.env.PROMETHEUS_EXPORTER_PORT || 5000,
+  VALIDATION_ERROR_CHANNEL: process.env.VALIDATION_ERROR_CHANNEL || 'validation_error',
 };
 
 module.exports = config;

--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@ const config = {
   PROMETHEUS_EXPORTER: process.env.PROMETHEUS_EXPORTER_ENABLED || false,
   PROMETHEUS_PORT: process.env.PROMETHEUS_EXPORTER_PORT || 5000,
   VALIDATION_ERROR_CHANNEL: process.env.VALIDATION_ERROR_CHANNEL || 'validation_error',
-  VALIDATION_ERROR_SCHEMA_URL: process.env.VALIDATION_SCHEMA_URL || '',
+  VALIDATION_ERROR_SCHEMA_URL: process.env.VALIDATION_SCHEMA_URL || false,
 };
 
 module.exports = config;

--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@ const config = {
   PROMETHEUS_EXPORTER: process.env.PROMETHEUS_EXPORTER_ENABLED || false,
   PROMETHEUS_PORT: process.env.PROMETHEUS_EXPORTER_PORT || 5000,
   VALIDATION_ERROR_CHANNEL: process.env.VALIDATION_ERROR_CHANNEL || 'validation_error',
-  VALIDATION_ERROR_SCHEMA_URL: process.env.VALIDATION_SCHEMA_URL || false,
+  VALIDATION_ERROR_SCHEMA_URL: process.env.VALIDATION_ERROR_SCHEMA_URL || false,
 };
 
 module.exports = config;

--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@ const config = {
   PROMETHEUS_EXPORTER: process.env.PROMETHEUS_EXPORTER_ENABLED || false,
   PROMETHEUS_PORT: process.env.PROMETHEUS_EXPORTER_PORT || 5000,
   VALIDATION_ERROR_CHANNEL: process.env.VALIDATION_ERROR_CHANNEL || 'validation_error',
-  VALIDATION_SCHEMA_URL: process.env.VALIDATION_SCHEMA_URL || '',
+  VALIDATION_ERROR_SCHEMA_URL: process.env.VALIDATION_SCHEMA_URL || '',
 };
 
 module.exports = config;

--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,7 @@ const config = {
   PROMETHEUS_EXPORTER: process.env.PROMETHEUS_EXPORTER_ENABLED || false,
   PROMETHEUS_PORT: process.env.PROMETHEUS_EXPORTER_PORT || 5000,
   VALIDATION_ERROR_CHANNEL: process.env.VALIDATION_ERROR_CHANNEL || 'validation_error',
+  VALIDATION_SCHEMA_URL: process.env.VALIDATION_SCHEMA_URL || '',
 };
 
 module.exports = config;

--- a/src/config.js
+++ b/src/config.js
@@ -8,6 +8,7 @@ const config = {
   PROMETHEUS_PORT: process.env.PROMETHEUS_EXPORTER_PORT || 5000,
   VALIDATION_ERROR_CHANNEL: process.env.VALIDATION_ERROR_CHANNEL || 'validation_error',
   VALIDATION_ERROR_SCHEMA_URL: process.env.VALIDATION_ERROR_SCHEMA_URL || false,
+  PUBLISH_INVALID: !(process.env.PUBLISH_INVALID == 'false'),
 };
 
 module.exports = config;

--- a/src/prometheus.js
+++ b/src/prometheus.js
@@ -1,11 +1,11 @@
 'use strict';
 let express = require('express');
 let client = require('prom-client');
-let config = require('./config')
+let config = require('./config');
 client.collectDefaultMetrics({timeout: 30000});
 
 const receiveCount = new client.Counter({
-  name: 'pubsub_rest_proxy_message_total',
+  name: 'pubsub_rest_proxy_receive_total',
   help: 'Count of all messages recieved by pubsub-rest-proxy',
 });
 
@@ -22,6 +22,12 @@ const requestSummary = new client.Summary({
   ageBuckets: 5,
 });
 
+const messageCount = new client.Counter({
+  name: 'pubsub_rest_proxy_message_total',
+  help: 'Count of all individual messages published by pubsub-rest-proxy',
+  labelNames: ['state'],
+});
+
 let app = express();
 
 app.get('/metrics', (req, res) => {
@@ -34,7 +40,8 @@ if( config.PROMETHEUS_EXPORTER ) {
 }
 
 module.exports = {
-  receiveCount,
+  messageCount,
   publishCount,
+  receiveCount,
   requestSummary,
 };

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -7,5 +7,32 @@ let ConnectionFactory = pubSubManager.PubSubConnectionFactory;
 // create pubsub manager
 let connectionFactory = new ConnectionFactory();
 let manager = new PubSubManager(connectionFactory, pubSubManager.config);
+let connection = manager.connection();
+let config = require('./config');
+let validator = require('./validator');
 
-module.exports = manager;
+let publish = async (channel, messages) => {
+  let errors = [];
+  let validMessages = [];
+  let invalidMessages = [];
+  await Promise.all(messages.map((message)=>{
+    return validator.validate(message).then(()=>{
+      validMessages.push(message);
+      return connection.publish(channel, message);
+    }).catch((error) => {
+      if(error.name == 'ValidationError') {
+        invalidMessages.push(error.event);
+        return connection.publish(config.VALIDATION_ERROR_CHANNEL, error.event);
+      } else {
+        errors.push(message);
+        return new Error(error);
+      }
+    });
+  }));
+
+  return {validMessages, invalidMessages, errors};
+};
+
+module.exports = {
+  publish,
+};

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -17,25 +17,31 @@ let publish = async (channel, messages) => {
   let errors = [];
   let validMessages = [];
   let invalidMessages = [];
+  // Map all messages to validate and publish each individually.
   await Promise.all(messages.map((message)=>{
     return validator.validate(message).then(()=>{
       validMessages.push(message);
+      // If a message is valid then publish it.
       return connection.publish(channel, message);
     }).catch((error) => {
       if(error.name == 'ValidationError') {
-        logger.warning('ValidationError: '+channel+' - '+error.event.errors);
+        logger.warn('ValidationError: '+channel+' - '+error.event.errors);
         invalidMessages.push(error.event);
+        // If it is not valid then publish the invalid event to a separate channel
         return connection.publish(config.VALIDATION_ERROR_CHANNEL, error.event);
       } else {
+        // Throw an exception if it cannot publish or run validation.
         throw new Error(error);
       }
     }).catch((error) => {
+      // Add messages with errors to the errors array.
       errors.push(message);
-      logger.error(message);
+      logger.error(error);
       return error;
     });
   }));
-
+  // Return an object with all messages. errors may contain valid and invalid
+  // messages that were unable to be published.
   return {validMessages, invalidMessages, errors};
 };
 

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -26,7 +26,7 @@ let publish = async (channel, messages) => {
       return connection.publish(channel, message);
     }).catch((error) => {
       if(error.name == 'ValidationError') {
-        logger.warn('ValidationError: '+channel+' - '+error.event.errors);
+        logger.warn(`ValidationError: ${channel} - ${error.event.errors}`);
         invalidMessages.push(error.event);
         // If it is not valid then publish the invalid event to a separate channel
         // For now we're going to dual publish the invalid messages.

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -32,7 +32,7 @@ let publish = async (channel, messages) => {
         connection.publish(config.VALIDATION_ERROR_CHANNEL, error.event);
         // For now we're going to dual publish the invalid messages.
         // Wrap it in a try catch so that if it fails but publish succeeds it doesn't
-        // dual publish.
+        // publish the same event twice.
         try{
           prom.messageCount.inc({state: 'invalid'});
         } catch(error) {

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -11,6 +11,8 @@ let connection = manager.connection();
 let config = require('./config');
 let validator = require('./validator');
 
+let logger = require('./logger');
+
 let publish = async (channel, messages) => {
   let errors = [];
   let validMessages = [];
@@ -21,12 +23,16 @@ let publish = async (channel, messages) => {
       return connection.publish(channel, message);
     }).catch((error) => {
       if(error.name == 'ValidationError') {
+        logger.warning('ValidationError: '+channel+' - '+error.event.errors);
         invalidMessages.push(error.event);
         return connection.publish(config.VALIDATION_ERROR_CHANNEL, error.event);
       } else {
-        errors.push(message);
-        return new Error(error);
+        throw new Error(error);
       }
+    }).catch((error) => {
+      errors.push(message);
+      logger.error(message);
+      return error;
     });
   }));
 

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -3,7 +3,7 @@
 let pubSubManager = require('@superbalist/js-pubsub-manager');
 let PubSubManager = pubSubManager.PubSubManager;
 let ConnectionFactory = pubSubManager.PubSubConnectionFactory;
-
+let prom = require('./prometheus');
 // create pubsub manager
 let connectionFactory = new ConnectionFactory();
 let manager = new PubSubManager(connectionFactory, pubSubManager.config);
@@ -22,18 +22,29 @@ let publish = async (channel, messages) => {
     return validator.validate(message).then(()=>{
       validMessages.push(message);
       // If a message is valid then publish it.
+      prom.messageCount.inc({state: 'valid'})
       return connection.publish(channel, message);
     }).catch((error) => {
       if(error.name == 'ValidationError') {
         logger.warn('ValidationError: '+channel+' - '+error.event.errors);
         invalidMessages.push(error.event);
         // If it is not valid then publish the invalid event to a separate channel
-        return connection.publish(config.VALIDATION_ERROR_CHANNEL, error.event);
+        connection.publish(config.VALIDATION_ERROR_CHANNEL, error.event);
+        // For now we're going to dual publish the invalid messages.
+        // Wrap it in a try catch so that if it fails but publish succeeds it doesn't
+        // dual publish.
+        try{
+          prom.messageCount.inc({state: 'invalid'});
+        } catch(error) {
+          // Do nothing
+        }
+        return connection.publish(channel, message);
       } else {
         // Throw an exception if it cannot publish or run validation.
         throw new Error(error);
       }
     }).catch((error) => {
+      // This could be errors in validation or publishing
       // Add messages with errors to the errors array.
       errors.push(message);
       logger.error(error);

--- a/src/validator.js
+++ b/src/validator.js
@@ -1,0 +1,54 @@
+let eventPubSub = require('@superbalist/js-event-pubsub');
+let Ajv = require('ajv');
+let request = require('request-promise-native');
+let JSONSchemaEventValidator = eventPubSub.validators.JSONSchemaEventValidator;
+
+let ajv = new Ajv({
+  extendRefs: true,
+  loadSchema: (uri) => {
+    return request({uri: uri, json: true});
+  },
+  allErrors: true,
+});
+ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
+
+let validator = new JSONSchemaEventValidator(ajv);
+let SchemaEvent = eventPubSub.events.SchemaEvent;
+
+/**
+ * ValidationError Class
+ */
+class ValidationError extends Error {
+  /**
+   * Construct a ValidationError
+   *
+   * @param {ValidationResult} validationResult
+   */
+  constructor(validationResult, ...params) {
+    // Pass remaining arguments (including vendor specific ones) to parent constructor
+    super(...params);
+    this.name = 'ValidationError';
+    // Custom debugging information
+    this.event = {
+      'schema': 'http://schema.superbalist.com/events/validation_error/validation_error/1.0.json',
+      'meta': validationResult.event.attributes.meta,
+      'event': validationResult.event.schema,
+      'errors': validationResult.errors,
+    };
+  }
+}
+
+let validate = (message) => {
+  return validator.validate(new SchemaEvent(message.schema, message))
+  .then((validationResult)=>{
+    if(validationResult.passes) {
+      return message;
+    } else {
+      throw new ValidationError(validationResult);
+    }
+  });
+};
+
+module.exports = {
+  validate,
+};

--- a/src/validator.js
+++ b/src/validator.js
@@ -56,7 +56,7 @@ if(config.VALIDATION_ERROR_SCHEMA_URL) {
   //  Override validation with ajv validation.
   validate = (message) => {
     if(!message.schema) {
-      logger.error('No schema: ' + JSON.stringify(message.meta));
+      logger.error(`No schema: ${JSON.stringify(message.meta)}`);
       return Promise.reject(new ValidationError({
         event: {
           attributes: {meta: message.meta},

--- a/src/validator.js
+++ b/src/validator.js
@@ -1,5 +1,5 @@
 const config = require('./config');
-
+const logger = require('./logger');
 //  By default validation is always happy
 let validate = () => {
   return Promise.resolve();
@@ -47,6 +47,15 @@ if(config.VALIDATION_ERROR_SCHEMA_URL) {
 
   //  Override validation with ajv validation.
   validate = (message) => {
+    if(!message.schema) {
+      logger.error('No schema: ' + JSON.stringify(message));
+      return Promise.reject(new ValidationError({
+        event: {
+          attributes: {meta: message.meta},
+        },
+        errors: ['No schema Provided'],
+      }));
+    }
     return validator.validate(new SchemaEvent(message.schema, message))
     .then((validationResult)=>{
       if(validationResult.passes) {

--- a/src/validator.js
+++ b/src/validator.js
@@ -30,7 +30,7 @@ class ValidationError extends Error {
     this.name = 'ValidationError';
     // Custom debugging information
     this.event = {
-      'schema': config.VALIDATION_SCHEMA_URL,
+      'schema': config.VALIDATION_ERROR_SCHEMA_URL,
       'meta': validationResult.event.attributes.meta,
       'event': validationResult.event.schema,
       'errors': validationResult.errors,

--- a/src/validator.js
+++ b/src/validator.js
@@ -1,53 +1,62 @@
-let eventPubSub = require('@superbalist/js-event-pubsub');
-let Ajv = require('ajv');
-let request = require('request-promise-native');
-let JSONSchemaEventValidator = eventPubSub.validators.JSONSchemaEventValidator;
 const config = require('./config');
-let ajv = new Ajv({
-  extendRefs: true,
-  loadSchema: (uri) => {
-    return request({uri: uri, json: true});
-  },
-  allErrors: true,
-});
-ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
 
-let validator = new JSONSchemaEventValidator(ajv);
-let SchemaEvent = eventPubSub.events.SchemaEvent;
-
-/**
- * ValidationError Class
- */
-class ValidationError extends Error {
-  /**
-   * Construct a ValidationError
-   *
-   * @param {ValidationResult} validationResult
-   */
-  constructor(validationResult, ...params) {
-    // Pass remaining arguments (including vendor specific ones) to parent constructor
-    super(...params);
-    this.name = 'ValidationError';
-    // Custom debugging information
-    this.event = {
-      'schema': config.VALIDATION_ERROR_SCHEMA_URL,
-      'meta': validationResult.event.attributes.meta,
-      'event': validationResult.event.schema,
-      'errors': validationResult.errors,
-    };
-  }
-}
-
-let validate = (message) => {
-  return validator.validate(new SchemaEvent(message.schema, message))
-  .then((validationResult)=>{
-    if(validationResult.passes) {
-      return message;
-    } else {
-      throw new ValidationError(validationResult);
-    }
-  });
+//  By default validation is always happy
+let validate = () => {
+  return Promise.resolve();
 };
+//  If a schema url is supplied then validation will occur
+if(config.VALIDATION_ERROR_SCHEMA_URL) {
+  let eventPubSub = require('@superbalist/js-event-pubsub');
+  let request = require('request-promise-native');
+  let JSONSchemaEventValidator = eventPubSub.validators.JSONSchemaEventValidator;
+
+  let Ajv = require('ajv');
+  let ajv = new Ajv({
+    extendRefs: true,
+    loadSchema: (uri) => {
+      return request({uri: uri, json: true});
+    },
+    allErrors: true,
+  });
+  ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
+
+  let validator = new JSONSchemaEventValidator(ajv);
+  let SchemaEvent = eventPubSub.events.SchemaEvent;
+  /**
+   * ValidationError Class
+   */
+  class ValidationError extends Error {
+    /**
+     * Construct a ValidationError
+     *
+     * @param {ValidationResult} validationResult
+     */
+    constructor(validationResult, ...params) {
+      // Pass remaining arguments (including vendor specific ones) to parent constructor
+      super(...params);
+      this.name = 'ValidationError';
+      // Custom debugging information
+      this.event = {
+        'schema': config.VALIDATION_ERROR_SCHEMA_URL,
+        'meta': validationResult.event.attributes.meta,
+        'event': validationResult.event.schema,
+        'errors': validationResult.errors,
+      };
+    }
+  }
+
+  //  Override validation with ajv validation.
+  validate = (message) => {
+    return validator.validate(new SchemaEvent(message.schema, message))
+    .then((validationResult)=>{
+      if(validationResult.passes) {
+        return message;
+      } else {
+        throw new ValidationError(validationResult);
+      }
+    });
+  };
+}
 
 module.exports = {
   validate,

--- a/src/validator.js
+++ b/src/validator.js
@@ -2,7 +2,7 @@ let eventPubSub = require('@superbalist/js-event-pubsub');
 let Ajv = require('ajv');
 let request = require('request-promise-native');
 let JSONSchemaEventValidator = eventPubSub.validators.JSONSchemaEventValidator;
-
+const config = require('./config');
 let ajv = new Ajv({
   extendRefs: true,
   loadSchema: (uri) => {
@@ -30,7 +30,7 @@ class ValidationError extends Error {
     this.name = 'ValidationError';
     // Custom debugging information
     this.event = {
-      'schema': 'http://schema.superbalist.com/events/validation_error/validation_error/1.0.json',
+      'schema': config.VALIDATION_SCHEMA_URL,
       'meta': validationResult.event.attributes.meta,
       'event': validationResult.event.schema,
       'errors': validationResult.errors,


### PR DESCRIPTION
We want to have validation on the proxy so that clients can be dumb about publishing.

Currently messages will dual publish if they are invalid. So they will still publish the invalid message but will also publish an invalid message event to a separate channel.

By default validation is disabled. 